### PR TITLE
Recognise upper case username fields

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -66,7 +66,7 @@ function _M.parse_password(pass_data)
     return nil
 end
 
-local username_fields = { "username", "user", "email", "login" }
+local username_fields = { "Username", "username", "User", "user", "Email", "email", "Login", "login" }
 local otp_field = "otpauth"
 
 function _M.parse_username(pass_data)


### PR DESCRIPTION
This change adds so that the upper case versions of the username field are
recognised.

The example on the official password-store web page includes "Username", i.e.
upper case U, which is why I've used it across all my files. It seems like a
simple enough change. An alternative would be to programmatically generate the
upper case versions but this is by far easier.